### PR TITLE
Use unmkinitramfs

### DIFF
--- a/debian-luks-suspend
+++ b/debian-luks-suspend
@@ -45,16 +45,8 @@ mount_initramfs() {
 
     mount -t tmpfs -o size=512m tmpfs ${INITRAMFS_DIR}
 
-    # extracts hybrid initrd.img to initramfs dir
-    if file -L ${INITRAMFS} | grep -q "ASCII cpio archive"; then
-        (cd ${INITRAMFS_DIR} &&
-            SKIP_BLOCKS=$(cpio -id < "${INITRAMFS}" 2>&1 | grep blocks | cut -d" " -f1) &&
-            dd status=none if="${INITRAMFS}" of="${INITRAMFS_DIR}/initrd.img.gz" bs=512 skip=$SKIP_BLOCKS 
-            zcat "${INITRAMFS_DIR}/initrd.img.gz" | cpio -id --quiet 
-            rm "${INITRAMFS_DIR}/initrd.img.gz")
-    else           
-        (cd ${INITRAMFS_DIR} &&  zcat ${INITRAMFS} | cpio -id --quiet)
-    fi
+    # extract initrd.img to initramfs dir
+    unmkinitramfs "${INITRAMFS}" "${INITRAMFS_DIR}"
 
     for p in ${BIND_PATHS}; do
         mkdir -p "${INITRAMFS_DIR}${p}"


### PR DESCRIPTION
It catches the two options we catched, and more
It's explicitly mentioned in https://wiki.debian.org/initramfs