### PR TITLE
Some vars weren't getting set, this caused set -u to exit script prematurely.

### DIFF
--- a/debian-luks-suspend
+++ b/debian-luks-suspend
@@ -86,7 +86,7 @@ for x in $(cat /proc/cmdline) ; do
 done
 
 # if plymouth is not disabled and it was used to boot, use it to resume
-[[ ${USE_PLYMOUTH="true"} == "true" && ${kernel_cmdline[splash]} ]] &&
+[[ ${USE_PLYMOUTH="true"} == "true" && -n "${kernel_cmdline[splash]+x}" ]] &&
     export USE_PLYMOUTH="true" || export USE_PLYMOUTH="false"
 
 # Retrieve cryptdevice name from boot command line

--- a/debian-luks-suspend
+++ b/debian-luks-suspend
@@ -58,8 +58,8 @@ unmount_initramfs() {
     for p in ${BIND_PATHS}; do
         umount "${INITRAMFS_DIR}${p}"
     done
-
-    if [[ "${INITRAMFS_DIR_ORIG}" != "${INITRAMFS_DIR}" ]] ; then
+    
+    if [[ -n "${INITRAMFS_DIR_ORIG+x}" && "${INITRAMFS_DIR_ORIG}" != "${INITRAMFS_DIR}" ]] ; then
         INITRAMFS_DIR=${INITRAMFS_DIR_ORIG}
     fi
     umount ${INITRAMFS_DIR}


### PR DESCRIPTION
The case of kernel_cmdline[splash] only affected me because I didn't realize you changed the systemd service file to include a var for using plymouth or not. Once I set that var to false then nothing would have ever checked for kernel_cmdline[spash] but I had already made the change once I figured that out and it's probably for the best anyway.

I'm not sure exactly what was going on in the mount_initramfs() and unmount_initramfs() functions but INITRAMFS_DIR_ORG wasn't being set because unmkinitramfs wasn't creating a /run/initramfs/main dir which and thus the check for that in mount_initramfs() failed, however in unmount_initramfs() the test "[[ "${INITRAMFS_DIR_ORIG}" != "${INITRAMFS_DIR}" ]]" fails and exits script because INITRAMFS_DIR_ORIG is unset. In this case even if set -u wasn't being used  /run/initramfs would fail to umount as it will be set to an empty string.